### PR TITLE
My OSX 10.10 was missing pySerial

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Install the mote library with pip, like so:
 pip install mote
 ```
 
+If while trying to execute the exemple you get the following error: 'ImportError: No module named serial'.
+They you neet to also install the Python Serial library, like so:
+```
+pip install pyserial
+```
+
 ###Raspberry Pi (Raspbian)
 
 We've created a super-easy installation script that will install all pre-requisites and get your Mote up and running in a jiffy. To run it fire up Terminal which you'll find in Menu -> Accessories -> Terminal on your Raspberry Pi desktop like so:


### PR DESCRIPTION
While trying the demo on Mac OSX 10.10, I noticed my installation was missing the serial library.
I am not sure if I run the Vanilla OSX Python or the brew version of Python, but I needed to do this for things to work, else:

```
python test.py
Traceback (most recent call last):
  File "test.py", line 6, in <module>
    from mote import Mote
  File "/usr/local/lib/python2.7/site-packages/mote/__init__.py", line 1, in <module>
    import serial
ImportError: No module named serial
```
