### PR TITLE
Fixed cheerlights example so that it works with Python 2.7 and Python 3

### DIFF
--- a/python/examples/cheerlights.py
+++ b/python/examples/cheerlights.py
@@ -35,7 +35,7 @@ try:
         channel = 1
         for col in f:
             col = col['field2']
-            r, g, b = tuple(ord(c) for c in col[1:].lower().decode('hex'))
+            r, g, b = tuple(c for c in bytearray.fromhex(col[1:]))
             for pixel in range(mote.get_pixel_count(channel)):
                 mote.set_pixel(channel, pixel, r, g, b)
             channel += 1        

--- a/python/examples/soft-cheerlights.py
+++ b/python/examples/soft-cheerlights.py
@@ -43,7 +43,7 @@ try:
         channel = 1
         for col in f:
             col = col['field2']
-            r, g, b = tuple(ord(c) for c in col[1:].lower().decode('hex'))
+            r, g, b = tuple(c for c in bytearray.fromhex(col[1:]))
             h,s,v = rgb_to_hsv(r,g,b)
             channels_colour_rgb[channel - 1][0] = r
             channels_colour_rgb[channel - 1][1] = g


### PR DESCRIPTION
The cheerlights example raises an error in Python 3 ( Issue #13 ) due to the use of `decode` which isn't available. Python 3 supports `bytes.fromhex`, however this isn't available in Python 2. As a middleground I've used `bytearray.fromhex` which is supported in both.