### PR TITLE
Add link to unofficial Rust library

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ In all cases you will have to enable the i2c bus.
 * Guides and tutorials - https://learn.pimoroni.com/mote
 * Function reference - http://docs.pimoroni.com/mote/
 * Get help - http://forums.pimoroni.com/c/support
+
+## Unofficial / Third-party libraries
+
+* Rust library by Tiziano Santoro - https://github.com/tiziano88/mote-rs


### PR DESCRIPTION
Following the same structure as https://github.com/pimoroni/scroll-phat-hd