### PR TITLE
Added brightness parameter as fix to error in test.py and the module test function

### DIFF
--- a/python/documentation/Function-reference.md
+++ b/python/documentation/Function-reference.md
@@ -34,7 +34,7 @@ Note the show() method required to update all pixels after calling set_pixel.
 
 ## get_pixel
 
-Gets the RGB colour of a single pixel on a single channel, using the following parameters:
+Gets the RGB colour of a single pixel and the brightness(not currently used) on a single channel, using the following parameters:
 
 channel: channel, either 1, 2, 3 or 4, corresponding to numbers on Mote  
 index: index of the pixel to set, starting at 0 (0-15 for 16 pixels sticks)  

--- a/python/examples/test.py
+++ b/python/examples/test.py
@@ -5,6 +5,12 @@ from colorsys import hsv_to_rgb
 
 from mote import Mote
 
+print("""Test
+
+Press Ctrl+C to exit.
+""")
+
+
 
 mote = Mote()
 
@@ -38,7 +44,7 @@ try:
     for step in range(170):
         for channel in range(4):
             for pixel in range(mote.get_pixel_count(channel + 1)):
-                r, g, b = [int(c * 0.99) for c in mote.get_pixel(channel + 1, pixel)]
+                r, g, b, z = [int(c * 0.99) for c in mote.get_pixel(channel + 1, pixel)]
                 mote.set_pixel(channel + 1, pixel, r, g, b)
 
         time.sleep(0.001)
@@ -55,6 +61,9 @@ try:
         mote.show()
         time.sleep(0.01)
         if brightness < 255: brightness += 1
+
+    mote.clear()
+    mote.show()
 
 except KeyboardInterrupt:
     mote.clear()

--- a/python/library/mote/__init__.py
+++ b/python/library/mote/__init__.py
@@ -296,7 +296,7 @@ if __name__ == "__main__":
         for step in range(170):
             for channel in range(4):
                 for pixel in range(num_pixels):
-                    r, g, b = [int(c * 0.99) for c in mote.get_pixel(channel + 1, pixel)]
+                    r, g, b, z = [int(c * 0.99) for c in mote.get_pixel(channel + 1, pixel)]
                     mote.set_pixel(channel + 1, pixel, r, g, b)
 
             time.sleep(0.001)


### PR DESCRIPTION
Found python/examples/test.py had fatal error when run
`Traceback (most recent call last):
  File "test.py", line 41, in <module>
    r, g, b = [int(c * 0.99) for c in mote.get_pixel(channel + 1, pixel)]
ValueError: too many values to unpack
`
This was duplicated in the python/library/mote/__init__.py module file

Found that **get_pixel** was returning **RGB+Brightness**, so fix was to accept a brightness parameter.

Also updated the documentation python/documentation/Function-reference.md to reference this.